### PR TITLE
Minimal updates to be importable from npm/yarn

### DIFF
--- a/export-csv.js
+++ b/export-csv.js
@@ -1,9 +1,9 @@
 /**
  * A small plugin for getting the CSV of a categorized chart
+ *
+ * From https://github.com/Appboy/export-csv, which is our fork of https://github.com/highslide-software/export-csv
  */
-(function (Highcharts) {
-
-
+module.exports = function setupExportCsv(Highcharts) {
     var each = Highcharts.each;
     var filename;
     Highcharts.Chart.prototype.getCSV = function () {
@@ -139,4 +139,4 @@
             }
         });
     }
-}(Highcharts));
+}

--- a/package.json
+++ b/package.json
@@ -1,27 +1,19 @@
 {
     "name": "export-csv",
     "version": "1.0.4",
-    "title": "Export Chart Data To CSV",
-    "demo": [
-        "http://jsfiddle.net/highcharts/cqjvD/",
-        "http://jsfiddle.net/highcharts/2Jyn5/"
-    ],
+    "description": "Export Chart Data To CSV",
+    "main": "export-csv.js",
     "author": {
         "name": "Torstein Hønsi",
         "url": "https://github.com/highslide-software"
     },
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "https://github.com/highslide-software/export-csv/blob/master/LICENSE"
-        }
-    ],
+    "license": "MIT",
     "description": "This feature allows the user to export the chart data to a csv file.",
     "keywords": [
      "export",
      "csv"
     ],
-    "dependencies": {
+    "peerDependencies": {
         "highcharts": ">=3.0.0"
     }
 }


### PR DESCRIPTION
This allows importing "export-csv" as a package referencing this github repo
and no longer depends on `Highcharts` being a global